### PR TITLE
INTERLOK-3321 add gson as dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ ext {
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.30'
   nettyVersion='4.1.50.Final'
-  grpcVersion='1.29.0'
+  grpcVersion='1.30.0'
+  protobufVersion='3.12.0'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {
@@ -105,6 +106,7 @@ dependencies {
   compile ("commons-codec:commons-codec:1.14")
   compile ("com.fasterxml.jackson.core:jackson-databind:2.11.0")
   compile ("com.google.guava:guava:29.0-jre")
+
   // Minimal netty specification
   implementation ("io.netty:netty-handler:$nettyVersion")
   implementation ("io.netty:netty-transport-native-epoll:$nettyVersion")
@@ -113,11 +115,17 @@ dependencies {
   implementation ("io.grpc:grpc-netty:$grpcVersion")
   implementation ("io.grpc:grpc-protobuf:$grpcVersion")
   implementation ("io.grpc:grpc-stub:$grpcVersion")
+
   // Some things appear to be pinned at 1.28.1 which refers to a missing class
   // in 1.29.0; gradle dependencies was required.
   implementation  ("io.grpc:grpc-auth:$grpcVersion")
   implementation  ("io.grpc:grpc-alts:$grpcVersion")
+
   implementation  ("com.google.code.gson:gson:2.8.6")
+  // Required because we attempt to create a protobuf message in PUSH_RESPONSE_TO_INTERLOK
+  implementation ("com.google.protobuf:protobuf-java-util:$protobufVersion")
+  implementation ("com.google.protobuf:protobuf-java:$protobufVersion")
+
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ dependencies {
   // in 1.29.0; gradle dependencies was required.
   implementation  ("io.grpc:grpc-auth:$grpcVersion")
   implementation  ("io.grpc:grpc-alts:$grpcVersion")
-
+  implementation  ("com.google.code.gson:gson:2.8.6")
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
 

--- a/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubConnection.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubConnection.java
@@ -56,7 +56,8 @@ public class GoogleCloudPubSubConnection extends ConnectionConfig {
     ProjectTopicName topic = ProjectTopicName.of(getProjectName(), config.getTopicName());
     try {
       Subscription subscription = getSubscriptionAdminClient().getSubscription(subscriptionName);
-      log.trace(String.format("Found existing subscription [%s] for Topic [%s]", config.getSubscriptionName(), subscription.getTopic()));
+      log.trace("Found existing subscription [{}] for Topic [{}]", config.getSubscriptionName(),
+          subscription.getTopic());
       if(!subscription.getTopic().equals(topic.toString())){
         throw new CoreException(String.format("Existing subscription topics do not match [%s] [%s]", subscription.getTopic(), topic.toString()));
       }

--- a/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubConnection.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubConnection.java
@@ -1,9 +1,8 @@
 package com.adaptris.google.cloud.pubsub;
 
 
+import javax.validation.constraints.NotBlank;
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.CoreException;
@@ -51,6 +50,7 @@ public class GoogleCloudPubSubConnection extends ConnectionConfig {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public ProjectSubscriptionName createSubscription(ConsumeConfig config) throws CoreException {
     ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(getProjectName(), config.getSubscriptionName());
     ProjectTopicName topic = ProjectTopicName.of(getProjectName(), config.getTopicName());
@@ -66,8 +66,13 @@ public class GoogleCloudPubSubConnection extends ConnectionConfig {
         throw new CoreException("Failed to retrieve Topic", e);
       } else {
         if (config.getCreateSubscription()){
-          log.trace(String.format("Creating Subscription [%s] Topic [%s]", config.getSubscriptionName(), topic.toString()));
-          Subscription subscription = getSubscriptionAdminClient().createSubscription(subscriptionName, topic, PushConfig.getDefaultInstance(), config.getAckDeadlineSeconds());
+          log.trace("Creating Subscription [{}] Topic [{}]", config.getSubscriptionName(),
+              topic.toString());
+          // could cast to TopicName since ProjectTopicName extends TopicName to avoid the
+          // deprecation warning
+          Subscription subscription =
+              getSubscriptionAdminClient().createSubscription(subscriptionName, topic,
+                  PushConfig.getDefaultInstance(), config.getAckDeadlineSeconds());
           return ProjectSubscriptionName.parse(subscription.getName());
         } else {
           throw new CoreException("Failed to retrieve Topic", e);

--- a/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubProducer.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubProducer.java
@@ -3,10 +3,8 @@ package com.adaptris.google.cloud.pubsub;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
@@ -97,11 +95,14 @@ public class GoogleCloudPubSubProducer extends ProduceOnlyProducerImp {
     }
   }
 
+  @SuppressWarnings("deprecation")
   ProjectTopicName createOrGetTopicName(AdaptrisMessage adaptrisMessage) throws CoreException {
     ProjectTopicName topicName = ProjectTopicName.of(projectName, getDestination().getDestination(adaptrisMessage));
     if(!getCreateTopic()){
       return topicName;
     }
+    // could cast to TopicName since ProjectTopicName extends TopicName to avoid the
+    // deprecation warning
     try {
       Topic topic = topicAdminClient.getTopic(topicName);
       return ProjectTopicName.parse(topic.getName());

--- a/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubProducer.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubProducer.java
@@ -78,10 +78,10 @@ public class GoogleCloudPubSubProducer extends ProduceOnlyProducerImp {
       String key = getDestination().getDestination(adaptrisMessage);
       Publisher publisher;
       if (publisherCache.containsKey(key)){
-        log.trace(String.format("Found publisher for key [%s]", key));
+        log.trace("Found publisher for key [{}]", key);
         publisher = publisherCache.get(key);
       } else {
-        log.trace(String.format("No publisher found for key [%s]", key));
+        log.trace("No publisher found for key [{}]", key);
         publisher = Publisher.newBuilder(createOrGetTopicName(adaptrisMessage))
             .setChannelProvider(channelProvider)
             .setCredentialsProvider(credentialsProvider)
@@ -89,7 +89,7 @@ public class GoogleCloudPubSubProducer extends ProduceOnlyProducerImp {
         publisherCache.put(key, publisher);
       }
       ApiFuture<String> messageId = publisher.publish(createPubsubMessage(adaptrisMessage));
-      log.debug(String.format("Published with message ID: %s", messageId.get()));
+      log.debug("Published with message ID: {}", messageId.get());
     } catch (IOException | CoreException | InterruptedException | ExecutionException e) {
       throw new ProduceException("Failed to Produce Message", e);
     }

--- a/src/main/java/com/adaptris/google/cloud/pubsub/MetadataReplyProvider.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/MetadataReplyProvider.java
@@ -1,9 +1,7 @@
 package com.adaptris.google.cloud.pubsub;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-
-import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
 import com.thoughtworks.xstream.annotations.XStreamAlias;

--- a/src/main/java/com/adaptris/google/cloud/pubsub/PublisherMap.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/PublisherMap.java
@@ -1,13 +1,14 @@
 package com.adaptris.google.cloud.pubsub;
 
-import com.google.cloud.pubsub.v1.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.cloud.pubsub.v1.Publisher;
 
 public class PublisherMap extends LinkedHashMap<String, Publisher> {
+
+  private static final long serialVersionUID = 2020060901L;
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 

--- a/src/main/java/com/adaptris/google/cloud/pubsub/TransformationDirection.java
+++ b/src/main/java/com/adaptris/google/cloud/pubsub/TransformationDirection.java
@@ -1,5 +1,7 @@
 package com.adaptris.google.cloud.pubsub;
 
+import java.io.IOException;
+import java.io.Reader;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MetadataCollection;
@@ -18,8 +20,6 @@ import com.google.pubsub.v1.PublishRequest;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
-
-import java.io.IOException;
 
 /**
  * Direction enum; Google Cloud Pub/Sub JSON <-> Interlok Messsage.
@@ -81,9 +81,8 @@ public enum TransformationDirection {
   PUSH_RESPONSE_TO_INTERLOK {
     @Override
     public void transform(AdaptrisMessage message, MetadataFilter metadataFilter) throws ServiceException {
-      try {
-        JsonParser jsonParser = new JsonParser();
-        JsonElement jsonRoot = jsonParser.parse(new String(message.getPayload()));
+      try (Reader reader = message.getReader()) {
+        JsonElement jsonRoot = JsonParser.parseReader(reader);
         String messageStr = jsonRoot.getAsJsonObject().get("message").toString();
         message.addMetadata("gcloud_subscription", jsonRoot.getAsJsonObject().get("subscription").toString());
         PubsubMessage.Builder pubsubMessage = PubsubMessage.newBuilder();


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok-gcloud-pubsub/pull/133 shows us that at the time, we didn't understand our dependencies vis-a-vis gcloud-pubsub. We explicitly use gson + protobuf-java + protobuf-java-util but we don't declare them as dependencies.

## Modification

Effectively, protobufVersion = 3.12.0, and also bumped grpcVersion to 1.30.0 to avoid extra dependabot work.

```
  implementation  ("com.google.code.gson:gson:2.8.6")
  // Required because we attempt to create a protobuf message in PUSH_RESPONSE_TO_INTERLOK
  implementation ("com.google.protobuf:protobuf-java-util:$protobufVersion")
  implementation ("com.google.protobuf:protobuf-java:$protobufVersion")
```

I also took the chance to remove some deprecation warnings and to tune the logging statements to avoid possibly non-trivial String.format() statements for trace logging.

## Result

Tests still pass.

## Testing

Use : https://github.com/adaptris-labs/interlok-gcloud-pubsub-interop

