### PR TITLE
INTERLOK-3403 Upgrade to mockito 3.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ target
 bin
 .gradle
 src/main/generated
+gradle.properties

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,8 @@ dependencies {
     changing= true
     exclude group: "org.apache.logging.log4j"
   }
-  testCompile ("org.mockito:mockito-all:1.10.19")
+  testCompile ("org.mockito:mockito-core:3.7.0")
+  testCompile ("org.mockito:mockito-inline:3.7.0")
   testCompile  ("org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1")
   testCompile  ("com.jayway.jsonpath:json-path:2.4.0")
   testImplementation  ("com.google.api.grpc:grpc-google-cloud-pubsub-v1:1.92.1")

--- a/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubProducerTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubProducerTest.java
@@ -3,22 +3,22 @@ package com.adaptris.google.cloud.pubsub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
-import org.mockito.Mockito;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ProducerCase;
 import com.adaptris.core.StandaloneRequestor;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.pubsub.v1.PubsubMessage;
 
-public class GoogleCloudPubSubProducerTest extends ProducerCase {
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class GoogleCloudPubSubProducerTest extends ExampleProducerCase {
 
   @Test
   public void testPrepare() throws Exception {
@@ -36,7 +36,7 @@ public class GoogleCloudPubSubProducerTest extends ProducerCase {
   @Test
   public void testClose() throws Exception {
     PublisherMap publisherMap = new PublisherMap(5);
-    Publisher publisher = Mockito.mock(Publisher.class);
+    Publisher publisher = mock(Publisher.class);
     publisherMap.put("key1",publisher);
     publisherMap.put("key2",null);
 
@@ -44,21 +44,21 @@ public class GoogleCloudPubSubProducerTest extends ProducerCase {
     producer.setPublisherCache(publisherMap);
     producer.close();
 
-    Mockito.verify(publisher, Mockito.times(1)).shutdown();
+    verify(publisher, times(1)).shutdown();
 
   }
 
   @Test
   public void testCloseException() throws Exception {
     PublisherMap publisherMap = new PublisherMap(5);
-    Publisher publisher = Mockito.mock(Publisher.class);
-    Mockito.doThrow(new IllegalArgumentException()).when(publisher).shutdown();
+    Publisher publisher = mock(Publisher.class);
+    doThrow(new IllegalArgumentException()).when(publisher).shutdown();
     publisherMap.put("key1",publisher);
     publisherMap.put("key2",null);
     GoogleCloudPubSubProducer producer = new GoogleCloudPubSubProducer();
     producer.setPublisherCache(publisherMap);
     producer.close();
-    Mockito.verify(publisher, Mockito.times(1)).shutdown();
+    verify(publisher, times(1)).shutdown();
 
   }
 

--- a/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubPullConsumerTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubPullConsumerTest.java
@@ -6,18 +6,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredConsumeDestination;
-import com.adaptris.core.ConsumerCase;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.oauth.gcloud.ApplicationDefaultCredentials;
 import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.google.cloud.pubsub.credentials.FixedCredentialsProvider;
+import com.adaptris.interlok.junit.scaffolding.ExampleConsumerCase;
 import com.adaptris.util.TimeInterval;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.Subscriber;
@@ -26,12 +29,7 @@ import com.google.protobuf.Timestamp;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
 
-public class GoogleCloudPubSubPullConsumerTest extends ConsumerCase {
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class GoogleCloudPubSubPullConsumerTest extends ExampleConsumerCase {
 
   @Test
   public void testConstruct() throws Exception {

--- a/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubResponseProducerTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubResponseProducerTest.java
@@ -3,21 +3,23 @@ package com.adaptris.google.cloud.pubsub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
-import org.mockito.Mockito;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ProducerCase;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 
-public class GoogleCloudPubSubResponseProducerTest extends ProducerCase {
+public class GoogleCloudPubSubResponseProducerTest extends ExampleProducerCase {
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   @Test
   public void testConstruct() throws Exception {
     GoogleCloudPubSubResponseProducer producer = new GoogleCloudPubSubResponseProducer();
@@ -32,36 +34,36 @@ public class GoogleCloudPubSubResponseProducerTest extends ProducerCase {
 
   @Test
   public void testProduceNullMetadata() throws Exception {
-    GoogleCloudPubSubResponseProducer producer = Mockito.spy(new GoogleCloudPubSubResponseProducer());
+    GoogleCloudPubSubResponseProducer producer = spy(new GoogleCloudPubSubResponseProducer());
     AdaptrisMessage msg =  AdaptrisMessageFactory.getDefaultInstance().newMessage();
     producer.produce(msg);
-    Mockito.verify(producer, Mockito.never()).getReplyProvider();
+    verify(producer, never()).getReplyProvider();
   }
 
   @Test
   public void testProduceNack() throws Exception {
-    GoogleCloudPubSubResponseProducer producer = Mockito.spy(new GoogleCloudPubSubResponseProducer());
+    GoogleCloudPubSubResponseProducer producer = spy(new GoogleCloudPubSubResponseProducer());
     producer.setReplyProvider(new ConfiguredReplyProvider(ReplyProvider.AckReply.NACK));
     AdaptrisMessage msg =  AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    AckReplyConsumer ackReplyConsumer = Mockito.mock(AckReplyConsumer.class);
+    AckReplyConsumer ackReplyConsumer = mock(AckReplyConsumer.class);
     msg.addObjectHeader(Constants.REPLY_KEY,ackReplyConsumer);
     producer.produce(msg);
-    Mockito.verify(producer, Mockito.times(1)).getReplyProvider();
-    Mockito.verify(ackReplyConsumer, Mockito.times(1)).nack();
-    Mockito.verify(ackReplyConsumer, Mockito.never()).ack();
+    verify(producer, times(1)).getReplyProvider();
+    verify(ackReplyConsumer, times(1)).nack();
+    verify(ackReplyConsumer, never()).ack();
   }
 
   @Test
   public void testProduceAck() throws Exception {
-    GoogleCloudPubSubResponseProducer producer = Mockito.spy(new GoogleCloudPubSubResponseProducer());
+    GoogleCloudPubSubResponseProducer producer = spy(new GoogleCloudPubSubResponseProducer());
     producer.setReplyProvider(new ConfiguredReplyProvider(ReplyProvider.AckReply.ACK));
     AdaptrisMessage msg =  AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    AckReplyConsumer ackReplyConsumer = Mockito.mock(AckReplyConsumer.class);
+    AckReplyConsumer ackReplyConsumer = mock(AckReplyConsumer.class);
     msg.addObjectHeader(Constants.REPLY_KEY,ackReplyConsumer);
     producer.produce(msg);
-    Mockito.verify(producer, Mockito.times(1)).getReplyProvider();
-    Mockito.verify(ackReplyConsumer, Mockito.times(1)).ack();
-    Mockito.verify(ackReplyConsumer, Mockito.never()).nack();
+    verify(producer, times(1)).getReplyProvider();
+    verify(ackReplyConsumer, times(1)).ack();
+    verify(ackReplyConsumer, never()).nack();
   }
 
   @Test
@@ -73,14 +75,14 @@ public class GoogleCloudPubSubResponseProducerTest extends ProducerCase {
 
   @Test
   public void testLifecycle() throws Exception {
-    GoogleCloudPubSubResponseProducer producer = Mockito.spy(new GoogleCloudPubSubResponseProducer());
+    GoogleCloudPubSubResponseProducer producer = spy(new GoogleCloudPubSubResponseProducer());
     LifecycleHelper.initAndStart(producer);
     LifecycleHelper.stopAndClose(producer);
-    Mockito.verify(producer, Mockito.times(1)).prepare();
-    Mockito.verify(producer, Mockito.times(1)).init();
-    Mockito.verify(producer, Mockito.times(1)).start();
-    Mockito.verify(producer, Mockito.times(1)).stop();
-    Mockito.verify(producer, Mockito.times(1)).close();
+    verify(producer, times(1)).prepare();
+    verify(producer, times(1)).init();
+    verify(producer, times(1)).start();
+    verify(producer, times(1)).stop();
+    verify(producer, times(1)).close();
   }
 
   @Test

--- a/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubTransformServiceTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/GoogleCloudPubSubTransformServiceTest.java
@@ -3,13 +3,16 @@ package com.adaptris.google.cloud.pubsub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.EnumSet;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
-import com.adaptris.core.transform.TransformServiceExample;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -18,11 +21,6 @@ import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
 public class GoogleCloudPubSubTransformServiceTest extends TransformServiceExample {
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   private Configuration jsonConfig;
 

--- a/src/test/java/com/adaptris/google/cloud/pubsub/PublisherMapTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/PublisherMapTest.java
@@ -3,8 +3,13 @@ package com.adaptris.google.cloud.pubsub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
-import org.mockito.Mockito;
+
 import com.google.cloud.pubsub.v1.Publisher;
 
 public class PublisherMapTest {
@@ -20,12 +25,12 @@ public class PublisherMapTest {
   @Test
   public void testRemoveEldestEntry() throws Exception {
     PublisherMap publisherMap = new PublisherMap(5);
-    Publisher publisher = Mockito.mock(Publisher.class);
-    publisherMap.put("key1",publisher);
-    publisherMap.put("key2",null);
-    publisherMap.put("key3",Mockito.mock(Publisher.class));
-    publisherMap.put("key4",Mockito.mock(Publisher.class));
-    publisherMap.put("key5",Mockito.mock(Publisher.class));
+    Publisher publisher = mock(Publisher.class);
+    publisherMap.put("key1", publisher);
+    publisherMap.put("key2", null);
+    publisherMap.put("key3", mock(Publisher.class));
+    publisherMap.put("key4", mock(Publisher.class));
+    publisherMap.put("key5", mock(Publisher.class));
 
     assertTrue(publisherMap.containsKey("key1"));
     assertTrue(publisherMap.containsKey("key2"));
@@ -33,7 +38,7 @@ public class PublisherMapTest {
     assertTrue(publisherMap.containsKey("key4"));
     assertTrue(publisherMap.containsKey("key5"));
 
-    publisherMap.put("key6",Mockito.mock(Publisher.class));
+    publisherMap.put("key6", mock(Publisher.class));
 
     assertFalse(publisherMap.containsKey("key1"));
     assertTrue(publisherMap.containsKey("key2"));
@@ -42,7 +47,7 @@ public class PublisherMapTest {
     assertTrue(publisherMap.containsKey("key5"));
     assertTrue(publisherMap.containsKey("key6"));
 
-    publisherMap.put("key7",Mockito.mock(Publisher.class));
+    publisherMap.put("key7", mock(Publisher.class));
 
     assertFalse(publisherMap.containsKey("key1"));
     assertFalse(publisherMap.containsKey("key2"));
@@ -52,20 +57,20 @@ public class PublisherMapTest {
     assertTrue(publisherMap.containsKey("key6"));
     assertTrue(publisherMap.containsKey("key7"));
 
-    Mockito.verify(publisher, Mockito.times(1)).shutdown();
+    verify(publisher, times(1)).shutdown();
 
   }
 
   @Test
   public void testRemoveEldestEntryException() throws Exception {
     PublisherMap publisherMap = new PublisherMap(5);
-    Publisher publisher = Mockito.mock(Publisher.class);
-    Mockito.doThrow(new IllegalArgumentException()).when(publisher).shutdown();
-    publisherMap.put("key1",publisher);
-    publisherMap.put("key2",null);
-    publisherMap.put("key3",Mockito.mock(Publisher.class));
-    publisherMap.put("key4",Mockito.mock(Publisher.class));
-    publisherMap.put("key5",Mockito.mock(Publisher.class));
+    Publisher publisher = mock(Publisher.class);
+    doThrow(new IllegalArgumentException()).when(publisher).shutdown();
+    publisherMap.put("key1", publisher);
+    publisherMap.put("key2", null);
+    publisherMap.put("key3", mock(Publisher.class));
+    publisherMap.put("key4", mock(Publisher.class));
+    publisherMap.put("key5", mock(Publisher.class));
 
     assertTrue(publisherMap.containsKey("key1"));
     assertTrue(publisherMap.containsKey("key2"));
@@ -73,7 +78,7 @@ public class PublisherMapTest {
     assertTrue(publisherMap.containsKey("key4"));
     assertTrue(publisherMap.containsKey("key5"));
 
-    publisherMap.put("key6",Mockito.mock(Publisher.class));
+    publisherMap.put("key6", mock(Publisher.class));
 
     assertFalse(publisherMap.containsKey("key1"));
     assertTrue(publisherMap.containsKey("key2"));
@@ -81,7 +86,7 @@ public class PublisherMapTest {
     assertTrue(publisherMap.containsKey("key4"));
     assertTrue(publisherMap.containsKey("key5"));
     assertTrue(publisherMap.containsKey("key6"));
-    Mockito.verify(publisher, Mockito.times(1)).shutdown();
+    verify(publisher, times(1)).shutdown();
   }
 
 

--- a/src/test/java/com/adaptris/google/cloud/pubsub/PubsubConnectionTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/PubsubConnectionTest.java
@@ -21,9 +21,13 @@ package com.adaptris.google.cloud.pubsub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import java.util.List;
+
 import org.junit.Test;
-import org.mockito.Mockito;
+
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.CoreException;
 import com.adaptris.google.cloud.pubsub.adminclient.SubscriptionAdminClientProvider;
@@ -39,6 +43,7 @@ import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.TopicName;
+
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
@@ -53,16 +58,16 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     boolean retainAckedMessages = false;
     Subscription expectedResponse =
         Subscription.newBuilder()
-            .setName(name.toString())
-            .setTopic(topic.toString())
-            .setAckDeadlineSeconds(ackDeadlineSeconds2)
-            .setRetainAckedMessages(retainAckedMessages)
-            .build();
+        .setName(name.toString())
+        .setTopic(topic.toString())
+        .setAckDeadlineSeconds(ackDeadlineSeconds2)
+        .setRetainAckedMessages(retainAckedMessages)
+        .build();
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -88,16 +93,16 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     boolean retainAckedMessages = false;
     Subscription expectedResponse =
         Subscription.newBuilder()
-            .setName(name.toString())
-            .setTopic(topic.toString())
-            .setAckDeadlineSeconds(ackDeadlineSeconds2)
-            .setRetainAckedMessages(retainAckedMessages)
-            .build();
+        .setName(name.toString())
+        .setTopic(topic.toString())
+        .setAckDeadlineSeconds(ackDeadlineSeconds2)
+        .setRetainAckedMessages(retainAckedMessages)
+        .build();
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -119,8 +124,8 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     mockSubscriber.addException(exception);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -142,8 +147,8 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     mockSubscriber.addException(exception);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -169,16 +174,16 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     boolean retainAckedMessages = false;
     Subscription expectedResponse =
         Subscription.newBuilder()
-            .setName(name.toString())
-            .setTopic(topic.toString())
-            .setAckDeadlineSeconds(ackDeadlineSeconds2)
-            .setRetainAckedMessages(retainAckedMessages)
-            .build();
+        .setName(name.toString())
+        .setTopic(topic.toString())
+        .setAckDeadlineSeconds(ackDeadlineSeconds2)
+        .setRetainAckedMessages(retainAckedMessages)
+        .build();
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -206,8 +211,8 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -230,8 +235,8 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubPullConsumer consumer = new GoogleCloudPubSubPullConsumer();
@@ -252,16 +257,16 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     boolean retainAckedMessages = false;
     Subscription expectedResponse =
         Subscription.newBuilder()
-            .setName(name.toString())
-            .setTopic(topic.toString())
-            .setAckDeadlineSeconds(ackDeadlineSeconds2)
-            .setRetainAckedMessages(retainAckedMessages)
-            .build();
+        .setName(name.toString())
+        .setTopic(topic.toString())
+        .setAckDeadlineSeconds(ackDeadlineSeconds2)
+        .setRetainAckedMessages(retainAckedMessages)
+        .build();
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     connection.setCredentialsProvider(new MockCredentialsProvider(credentialsProvider));
@@ -294,16 +299,16 @@ public class PubsubConnectionTest extends ServiceHelperBase {
     boolean retainAckedMessages = false;
     Subscription expectedResponse =
         Subscription.newBuilder()
-            .setName(name.toString())
-            .setTopic(topic.toString())
-            .setAckDeadlineSeconds(ackDeadlineSeconds2)
-            .setRetainAckedMessages(retainAckedMessages)
-            .build();
+        .setName(name.toString())
+        .setTopic(topic.toString())
+        .setAckDeadlineSeconds(ackDeadlineSeconds2)
+        .setRetainAckedMessages(retainAckedMessages)
+        .build();
     mockSubscriber.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    SubscriptionAdminClientProvider provider = Mockito.mock(SubscriptionAdminClientProvider.class);
-    Mockito.doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
+    SubscriptionAdminClientProvider provider = mock(SubscriptionAdminClientProvider.class);
+    doReturn(subscriptionAdminClient).when(provider).getSubscriptionAdminClient();
     connection.setSubscriptionAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     connection.setCredentialsProvider(new MockCredentialsProvider(credentialsProvider));

--- a/src/test/java/com/adaptris/google/cloud/pubsub/PubsubProducerTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/PubsubProducerTest.java
@@ -21,9 +21,13 @@ package com.adaptris.google.cloud.pubsub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import java.util.List;
+
 import org.junit.Test;
-import org.mockito.Mockito;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -39,11 +43,11 @@ import com.google.pubsub.v1.PublishRequest;
 import com.google.pubsub.v1.PublishResponse;
 import com.google.pubsub.v1.Topic;
 import com.google.pubsub.v1.TopicName;
+
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
 public class PubsubProducerTest extends ServiceHelperBase {
-
 
   @Test
   @SuppressWarnings("all")
@@ -52,8 +56,8 @@ public class PubsubProducerTest extends ServiceHelperBase {
     mockPublisher.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    TopicAdminClientProvider provider = Mockito.mock(TopicAdminClientProvider.class);
-    Mockito.doReturn(topicAdminClient).when(provider).getTopicAdminClient();
+    TopicAdminClientProvider provider = mock(TopicAdminClientProvider.class);
+    doReturn(topicAdminClient).when(provider).getTopicAdminClient();
     connection.setTopicAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubProducer producer = new GoogleCloudPubSubProducer();
@@ -84,8 +88,8 @@ public class PubsubProducerTest extends ServiceHelperBase {
     mockPublisher.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    TopicAdminClientProvider provider = Mockito.mock(TopicAdminClientProvider.class);
-    Mockito.doReturn(topicAdminClient).when(provider).getTopicAdminClient();
+    TopicAdminClientProvider provider = mock(TopicAdminClientProvider.class);
+    doReturn(topicAdminClient).when(provider).getTopicAdminClient();
     connection.setTopicAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubProducer producer = new GoogleCloudPubSubProducer();
@@ -118,8 +122,8 @@ public class PubsubProducerTest extends ServiceHelperBase {
     mockPublisher.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    TopicAdminClientProvider provider = Mockito.mock(TopicAdminClientProvider.class);
-    Mockito.doReturn(topicAdminClient).when(provider).getTopicAdminClient();
+    TopicAdminClientProvider provider = mock(TopicAdminClientProvider.class);
+    doReturn(topicAdminClient).when(provider).getTopicAdminClient();
     connection.setTopicAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubProducer producer = new GoogleCloudPubSubProducer();
@@ -148,8 +152,8 @@ public class PubsubProducerTest extends ServiceHelperBase {
     mockPublisher.addException(exception);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    TopicAdminClientProvider provider = Mockito.mock(TopicAdminClientProvider.class);
-    Mockito.doReturn(topicAdminClient).when(provider).getTopicAdminClient();
+    TopicAdminClientProvider provider = mock(TopicAdminClientProvider.class);
+    doReturn(topicAdminClient).when(provider).getTopicAdminClient();
     connection.setTopicAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     GoogleCloudPubSubProducer producer = new GoogleCloudPubSubProducer();
@@ -181,8 +185,8 @@ public class PubsubProducerTest extends ServiceHelperBase {
     mockPublisher.addResponse(expectedResponse);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    TopicAdminClientProvider provider = Mockito.mock(TopicAdminClientProvider.class);
-    Mockito.doReturn(topicAdminClient).when(provider).getTopicAdminClient();
+    TopicAdminClientProvider provider = mock(TopicAdminClientProvider.class);
+    doReturn(topicAdminClient).when(provider).getTopicAdminClient();
     connection.setTopicAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     connection.setCredentialsProvider(new MockCredentialsProvider(credentialsProvider));
@@ -224,8 +228,8 @@ public class PubsubProducerTest extends ServiceHelperBase {
     mockPublisher.addException(exception);
 
     GoogleCloudPubSubConnection connection = new GoogleCloudPubSubConnection();
-    TopicAdminClientProvider provider = Mockito.mock(TopicAdminClientProvider.class);
-    Mockito.doReturn(topicAdminClient).when(provider).getTopicAdminClient();
+    TopicAdminClientProvider provider = mock(TopicAdminClientProvider.class);
+    doReturn(topicAdminClient).when(provider).getTopicAdminClient();
     connection.setTopicAdminClientProvider(provider);
     connection.setProjectName(PROJECT);
     connection.setCredentialsProvider(new MockCredentialsProvider(credentialsProvider));

--- a/src/test/java/com/adaptris/google/cloud/pubsub/adminclient/SubscriptionAdminClientProviderTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/adminclient/SubscriptionAdminClientProviderTest.java
@@ -1,28 +1,31 @@
 package com.adaptris.google.cloud.pubsub.adminclient;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcTransportChannel;
-import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import io.grpc.ManagedChannel;
-import org.junit.Test;
-import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import io.grpc.ManagedChannel;
 
 public class SubscriptionAdminClientProviderTest {
 
   @Test
   public void testLifeCycle() throws  Exception {
     SubscriptionAdminClientProvider adminClientProvider = new SubscriptionAdminClientProvider();
-    TransportChannelProvider channelProvider = Mockito.mock(TransportChannelProvider.class);
-    Mockito.doReturn("grpc").when(channelProvider).getTransportName();
-    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(Mockito.mock(ManagedChannel.class));
-    Mockito.doReturn(managedChannel).when(channelProvider).getTransportChannel();
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    TransportChannelProvider channelProvider = mock(TransportChannelProvider.class);
+    doReturn("grpc").when(channelProvider).getTransportName();
+    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(mock(ManagedChannel.class));
+    doReturn(managedChannel).when(channelProvider).getTransportChannel();
+    CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
     adminClientProvider.setChannelProvider(channelProvider);
     adminClientProvider.setCredentialsProvider(credentialsProvider);
     LifecycleHelper.initAndStart(adminClientProvider);
@@ -33,11 +36,11 @@ public class SubscriptionAdminClientProviderTest {
   @Test
   public void testInit() throws  Exception {
     SubscriptionAdminClientProvider adminClientProvider = new SubscriptionAdminClientProvider();
-    TransportChannelProvider channelProvider = Mockito.mock(TransportChannelProvider.class);
-    Mockito.doReturn("grpc").when(channelProvider).getTransportName();
-    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(Mockito.mock(ManagedChannel.class));
-    Mockito.doReturn(managedChannel).when(channelProvider).getTransportChannel();
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    TransportChannelProvider channelProvider = mock(TransportChannelProvider.class);
+    doReturn("grpc").when(channelProvider).getTransportName();
+    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(mock(ManagedChannel.class));
+    doReturn(managedChannel).when(channelProvider).getTransportChannel();
+    CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
     initFail(adminClientProvider,"ChannelProvider can not be null");
     adminClientProvider.setChannelProvider(channelProvider);
     initFail(adminClientProvider,"CredentialsProvider can not be null");

--- a/src/test/java/com/adaptris/google/cloud/pubsub/adminclient/TopicAdminClientProviderTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/adminclient/TopicAdminClientProviderTest.java
@@ -1,26 +1,31 @@
 package com.adaptris.google.cloud.pubsub.adminclient;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import io.grpc.ManagedChannel;
-import org.junit.Test;
-import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import io.grpc.ManagedChannel;
 
 public class TopicAdminClientProviderTest {
 
   @Test
   public void testLifeCycle() throws  Exception {
     TopicAdminClientProvider adminClientProvider = new TopicAdminClientProvider();
-    TransportChannelProvider channelProvider = Mockito.mock(TransportChannelProvider.class);
-    Mockito.doReturn("grpc").when(channelProvider).getTransportName();
-    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(Mockito.mock(ManagedChannel.class));
-    Mockito.doReturn(managedChannel).when(channelProvider).getTransportChannel();
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    TransportChannelProvider channelProvider = mock(TransportChannelProvider.class);
+    doReturn("grpc").when(channelProvider).getTransportName();
+    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(mock(ManagedChannel.class));
+    doReturn(managedChannel).when(channelProvider).getTransportChannel();
+    CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
     adminClientProvider.setChannelProvider(channelProvider);
     adminClientProvider.setCredentialsProvider(credentialsProvider);
     LifecycleHelper.initAndStart(adminClientProvider);
@@ -31,11 +36,11 @@ public class TopicAdminClientProviderTest {
   @Test
   public void testInit() throws  Exception {
     TopicAdminClientProvider adminClientProvider = new TopicAdminClientProvider();
-    TransportChannelProvider channelProvider = Mockito.mock(TransportChannelProvider.class);
-    Mockito.doReturn("grpc").when(channelProvider).getTransportName();
-    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(Mockito.mock(ManagedChannel.class));
-    Mockito.doReturn(managedChannel).when(channelProvider).getTransportChannel();
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    TransportChannelProvider channelProvider = mock(TransportChannelProvider.class);
+    doReturn("grpc").when(channelProvider).getTransportName();
+    GrpcTransportChannel managedChannel = GrpcTransportChannel.create(mock(ManagedChannel.class));
+    doReturn(managedChannel).when(channelProvider).getTransportChannel();
+    CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
     initFail(adminClientProvider,"ChannelProvider can not be null");
     adminClientProvider.setChannelProvider(channelProvider);
     initFail(adminClientProvider,"CredentialsProvider can not be null");

--- a/src/test/java/com/adaptris/google/cloud/pubsub/channel/CustomChannelProviderTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/channel/CustomChannelProviderTest.java
@@ -1,13 +1,23 @@
 package com.adaptris.google.cloud.pubsub.channel;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import static org.junit.Assert.*;
 
 public class CustomChannelProviderTest {
 
@@ -26,25 +36,25 @@ public class CustomChannelProviderTest {
 
   @Test
   public void testInit() throws Exception {
-    CustomChannelProvider provider = Mockito.spy(new CustomChannelProvider());
+    CustomChannelProvider provider = spy(new CustomChannelProvider());
     provider.setAddress("localhost:9999");
     provider.setUsePlaintext(true);
     LifecycleHelper.initAndStart(provider);
     assertTrue(provider.getChannelProvider() instanceof FixedTransportChannelProvider);
-    Mockito.verify(provider,Mockito.times(1)).init();
-    Mockito.verify(provider,Mockito.times(1)).start();
-    Mockito.verify(provider,Mockito.times(1)).validateArguments();
-    Mockito.verify(provider,Mockito.times(1)).setChannelProvider(Mockito.any(FixedTransportChannelProvider.class));
+    verify(provider, times(1)).init();
+    verify(provider, times(1)).start();
+    verify(provider, times(1)).validateArguments();
+    verify(provider, times(1)).setChannelProvider(any(FixedTransportChannelProvider.class));
   }
 
   @Test
   public void testStopClose() throws Exception{
-    CustomChannelProvider provider = Mockito.spy(new CustomChannelProvider());
+    CustomChannelProvider provider = spy(new CustomChannelProvider());
     LifecycleHelper.stopAndClose(provider);
-    Mockito.verify(provider,Mockito.times(1)).stop();
-    Mockito.verify(provider,Mockito.times(1)).close();
-    Mockito.verify(provider,Mockito.never()).validateArguments();
-    Mockito.verify(provider,Mockito.never()).setChannelProvider(Mockito.any(FixedTransportChannelProvider.class));
+    verify(provider, times(1)).stop();
+    verify(provider, times(1)).close();
+    verify(provider, never()).validateArguments();
+    verify(provider, never()).setChannelProvider(any(FixedTransportChannelProvider.class));
   }
 
   @Test

--- a/src/test/java/com/adaptris/google/cloud/pubsub/channel/DefaultChannelProviderTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/channel/DefaultChannelProviderTest.java
@@ -1,34 +1,39 @@
 package com.adaptris.google.cloud.pubsub.channel;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
 import com.adaptris.core.util.LifecycleHelper;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import static org.junit.Assert.assertTrue;
 
 public class DefaultChannelProviderTest {
 
   @Test
   public void testInit() throws Exception {
-    DefaultChannelProvider provider = Mockito.spy(new DefaultChannelProvider());
+    DefaultChannelProvider provider = spy(new DefaultChannelProvider());
     LifecycleHelper.initAndStart(provider);
     assertTrue(provider.getChannelProvider() instanceof InstantiatingGrpcChannelProvider);
-    Mockito.verify(provider,Mockito.times(1)).init();
-    Mockito.verify(provider,Mockito.times(1)).start();
-    Mockito.verify(provider,Mockito.times(1)).validateArguments();
-    Mockito.verify(provider,Mockito.times(1)).setChannelProvider(Mockito.any(InstantiatingGrpcChannelProvider.class));
+    verify(provider, times(1)).init();
+    verify(provider, times(1)).start();
+    verify(provider, times(1)).validateArguments();
+    verify(provider, times(1)).setChannelProvider(any(InstantiatingGrpcChannelProvider.class));
   }
 
   @Test
   public void testStopClose() throws Exception{
-    DefaultChannelProvider provider = Mockito.spy(new DefaultChannelProvider());
+    DefaultChannelProvider provider = spy(new DefaultChannelProvider());
     LifecycleHelper.stopAndClose(provider);
-    Mockito.verify(provider,Mockito.times(1)).stop();
-    Mockito.verify(provider,Mockito.times(1)).close();
-    Mockito.verify(provider,Mockito.never()).validateArguments();
-    Mockito.verify(provider,Mockito.never()).setChannelProvider(Mockito.any(InstantiatingGrpcChannelProvider.class));
+    verify(provider, times(1)).stop();
+    verify(provider, times(1)).close();
+    verify(provider, never()).validateArguments();
+    verify(provider, never()).setChannelProvider(any(InstantiatingGrpcChannelProvider.class));
   }
 
   @Test

--- a/src/test/java/com/adaptris/google/cloud/pubsub/credentials/FixedCredentialsProviderTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/credentials/FixedCredentialsProviderTest.java
@@ -1,13 +1,22 @@
 package com.adaptris.google.cloud.pubsub.credentials;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.oauth.gcloud.Credentials;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.google.cloud.pubsub.stubs.StubCredentials;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import static org.junit.Assert.*;
 
 
 public class FixedCredentialsProviderTest {
@@ -17,21 +26,23 @@ public class FixedCredentialsProviderTest {
     FixedCredentialsProvider provider = new FixedCredentialsProvider();
     assertNull(provider.getCredentials());
     provider = new FixedCredentialsProvider(new StubCredentials());
+
     assertNotNull(provider.getCredentials());
     assertTrue(provider.getCredentials() instanceof StubCredentials);
   }
 
   @Test
   public void testInit() throws Exception {
-    Credentials credentials =  Mockito.spy(new StubCredentials());
-    FixedCredentialsProvider provider = Mockito.spy(new FixedCredentialsProvider(credentials));
+    Credentials credentials = spy(new StubCredentials());
+    FixedCredentialsProvider provider = spy(new FixedCredentialsProvider(credentials));
     LifecycleHelper.initAndStart(provider);
+
     assertTrue(provider.getCredentialsProvider() instanceof com.google.api.gax.core.FixedCredentialsProvider);
-    Mockito.verify(provider,Mockito.times(1)).init();
-    Mockito.verify(provider,Mockito.times(1)).start();
-    Mockito.verify(provider,Mockito.times(1)).setCredentialsProvider(Mockito.any(com.google.api.gax.core.NoCredentialsProvider.class));
-    Mockito.verify(credentials,Mockito.times(1)).init();
-    Mockito.verify(credentials,Mockito.times(1)).start();
+    verify(provider, times(1)).init();
+    verify(provider, times(1)).start();
+    verify(provider, times(1)).setCredentialsProvider(any(com.google.api.gax.core.FixedCredentialsProvider.class));
+    verify(credentials, times(1)).init();
+    verify(credentials, times(1)).start();
   }
 
   @Test
@@ -47,20 +58,22 @@ public class FixedCredentialsProviderTest {
 
   @Test
   public void testStopClose() throws Exception{
-    Credentials credentials =  Mockito.spy(new StubCredentials());
-    FixedCredentialsProvider provider = Mockito.spy(new FixedCredentialsProvider(credentials));
+    Credentials credentials = spy(new StubCredentials());
+    FixedCredentialsProvider provider = spy(new FixedCredentialsProvider(credentials));
     LifecycleHelper.stopAndClose(provider);
-    Mockito.verify(provider,Mockito.times(1)).stop();
-    Mockito.verify(provider,Mockito.times(1)).close();
-    Mockito.verify(provider,Mockito.never()).setCredentialsProvider(Mockito.any(com.google.api.gax.core.NoCredentialsProvider.class));
-    Mockito.verify(credentials,Mockito.times(1)).stop();
-    Mockito.verify(credentials,Mockito.times(1)).close();
+
+    verify(provider, times(1)).stop();
+    verify(provider, times(1)).close();
+    verify(provider, never()).setCredentialsProvider(any(com.google.api.gax.core.FixedCredentialsProvider.class));
+    verify(credentials, times(1)).stop();
+    verify(credentials, times(1)).close();
   }
 
   @Test
   public void testCreateCredentialsProvider() throws Exception {
     FixedCredentialsProvider provider = new FixedCredentialsProvider(new StubCredentials());
     com.google.api.gax.core.CredentialsProvider credentialsProvider = provider.createCredentialsProvider();
+
     assertTrue(credentialsProvider instanceof com.google.api.gax.core.FixedCredentialsProvider);
   }
 

--- a/src/test/java/com/adaptris/google/cloud/pubsub/credentials/NoCredentialsProviderTest.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/credentials/NoCredentialsProviderTest.java
@@ -1,31 +1,36 @@
 package com.adaptris.google.cloud.pubsub.credentials;
 
-import com.adaptris.core.util.LifecycleHelper;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import com.adaptris.core.util.LifecycleHelper;
 
 
 public class NoCredentialsProviderTest {
 
   @Test
   public void testInit() throws Exception {
-    NoCredentialsProvider provider = Mockito.spy(new NoCredentialsProvider());
+    NoCredentialsProvider provider = spy(new NoCredentialsProvider());
     LifecycleHelper.initAndStart(provider);
     assertTrue(provider.getCredentialsProvider() instanceof com.google.api.gax.core.NoCredentialsProvider);
-    Mockito.verify(provider,Mockito.times(1)).init();
-    Mockito.verify(provider,Mockito.times(1)).start();
-    Mockito.verify(provider,Mockito.times(1)).setCredentialsProvider(Mockito.any(com.google.api.gax.core.NoCredentialsProvider.class));
+    verify(provider, times(1)).init();
+    verify(provider, times(1)).start();
+    verify(provider, times(1)).setCredentialsProvider(any(com.google.api.gax.core.NoCredentialsProvider.class));
   }
 
   @Test
   public void testStopClose() throws Exception{
-    NoCredentialsProvider provider = Mockito.spy(new NoCredentialsProvider());
+    NoCredentialsProvider provider = spy(new NoCredentialsProvider());
     LifecycleHelper.stopAndClose(provider);
-    Mockito.verify(provider,Mockito.times(1)).stop();
-    Mockito.verify(provider,Mockito.times(1)).close();
-    Mockito.verify(provider,Mockito.never()).setCredentialsProvider(Mockito.any(com.google.api.gax.core.NoCredentialsProvider.class));
+    verify(provider, times(1)).stop();
+    verify(provider, times(1)).close();
+    verify(provider, never()).setCredentialsProvider(any(com.google.api.gax.core.NoCredentialsProvider.class));
   }
 
   @Test

--- a/src/test/java/com/adaptris/google/cloud/pubsub/stubs/StubCredentials.java
+++ b/src/test/java/com/adaptris/google/cloud/pubsub/stubs/StubCredentials.java
@@ -1,15 +1,15 @@
 package com.adaptris.google.cloud.pubsub.stubs;
 
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.oauth.gcloud.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import org.mockito.Mockito;
-
-import java.util.Date;
-
-import static org.mockito.Mockito.mock;
 
 public class StubCredentials implements Credentials {
 
@@ -20,7 +20,7 @@ public class StubCredentials implements Credentials {
 
   public StubCredentials() throws Exception{
     credentials = mock(GoogleCredentials.class);
-    Mockito.when(credentials.refreshAccessToken()).thenReturn(new AccessToken(ACCESS_TOKEN, EXPIRATION));
+    when(credentials.refreshAccessToken()).thenReturn(new AccessToken(ACCESS_TOKEN, EXPIRATION));
   }
 
   @Override


### PR DESCRIPTION
## Motivation

We want to upgrade all optional components to use the latest version of mockito

## Modification

- Upgrade to mockito 3.7.0
- Fix FixedCredentialsProviderTest#testInit
- Use static import
- Git igore gradle.properties

## Result

Upgrade done

## Testing

`gradlew check` should work.
